### PR TITLE
Updated lodash

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -7559,9 +7559,9 @@ lodash@^3.3.1, lodash@^3.5.0, lodash@^3.8.0:
   integrity sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=
 
 lodash@^4.0.0, lodash@^4.11.1, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.5.0, lodash@~4.17.10:
-  version "4.17.11"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
-  integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
+  version "4.17.15"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
+  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
 log-symbols@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Github Vulnerability Alert

Github alert ID: 120344742
Repository name: kabisa/kudos-frontend
Repository url: https://github.com/kabisa/kudos-frontend/network/alerts
Repository is private: false

Affected package: lodash
Affected version: < 4.17.13
External identifier: CVE-2019-10744
External reference: https://github.com/lodash/lodash/pull/4336
Fixed in version: 4.17.13
