### PR TITLE
Logout user when the backend responds with 401

### DIFF
--- a/src/apollo.js
+++ b/src/apollo.js
@@ -1,11 +1,18 @@
 import ApolloClient, { InMemoryCache } from "apollo-boost";
-
 import settings from "./config/settings";
+import { logout } from "./support/auth";
 
 const token = localStorage.getItem(settings.LOCALSTORAGE_TOKEN);
 
+const onError = ({ networkError }) => {
+  if (networkError && networkError.statusCode == 401) {
+    logout();
+  }
+};
+
 const client = new ApolloClient({
   uri: `${settings.API_BASE_URL}/graphql`,
+  onError,
   cache: new InMemoryCache(),
   headers: {
     Authorization: token ? `Bearer ${token}` : "",


### PR DESCRIPTION
This will happen when the authentication token is expired. The backend
doesn't support token refresh, so the user will have to login again to
obtain a new token.

This PR depends on https://github.com/kabisa/kudo-o-matic/pull/2.