### PR TITLE
Fix PullToRefresh not working as intended causing issues in touch scroll

### DIFF
--- a/src/components/templates/Page.module.css
+++ b/src/components/templates/Page.module.css
@@ -5,6 +5,8 @@
     "navigation"
     "main";
 
+  overflow: auto;
+
   height: 100vh;
 }
 

--- a/src/components/templates/Page.tsx
+++ b/src/components/templates/Page.tsx
@@ -1,11 +1,16 @@
 import { FC } from "react";
+import classNames from 'classnames';
 
 import { Navigation } from "../navigation";
 
 import styles from "./Page.module.css";
 
-const Page: FC = ({ children }) => (
-  <div className={styles.page}>
+type PageProps = {
+    className?: string;
+};
+
+const Page: FC<PageProps> = ({ children, className }) => (
+  <div className={ classNames(styles.page, className)}>
     <Navigation className={styles.navigation} />
     <main className={styles.main}>{children}</main>
   </div>

--- a/src/modules/feed/FeedPage.tsx
+++ b/src/modules/feed/FeedPage.tsx
@@ -39,7 +39,7 @@ export class FeedPage extends Component<FeedPageProps, FeedPageState> {
       },
       shouldPullToRefresh() {
         try {
-          return document.getElementsByClassName("page")[0].scrollTop === 0;
+          return document.getElementsByClassName("feed")[0].scrollTop === 0;
         } catch (error) {
           return true;
         }
@@ -49,7 +49,7 @@ export class FeedPage extends Component<FeedPageProps, FeedPageState> {
 
   render() {
     return (
-      <Page>
+      <Page className={"feed"}>
         <TabletAndBelow>
           <Segment>
             <CreatePost back={false} />


### PR DESCRIPTION
## What

The feed page implements src/components/PullToRefresh.js functionality to allow a refresh when "pulling" at the top of the page on touch screens. This depends on the scroll position of some element. Due to the refactoring this wasn't working as intended anymore, triggering refreshes at other scroll positions

## Why

Explain why these things are changes. This explanation is for your colleagues and your future self.

## Code Review

Please consider the following checklist when reviewing this Pull Request.  
More background and details [here](https://github.com/kabisa/kabisa-guide/blob/master/organization/process/code-review/README.md).

* [ ] Does the code **actually solve** the problem it was meant to solve?
* [ ] Is the code covered by **unit tests**? **Integration tests**?
* [ ] Does anything here need **documentation**? (Focus on *why*, not *what.*)
* [ ] Does any of this code deal with **privacy sensitive information** or affects **security**? Ask an additional reviewer.
* [ ] Is the code easy to **understand** and **change** in the future?
* [ ] Is the same code or concept **duplicated**? Find a balance between DRYness and readability.
* [ ] Does the code reasonably adhere to the Kabisa [**coding standards**](https://github.com/kabisa/kabisa-guide/blob/master/organization/process/code-review/README.md)?
* [ ] Be kind.
